### PR TITLE
Upgrade to Xamarin.Forms 3.4

### DIFF
--- a/Forms/MainPage.xaml.cs
+++ b/Forms/MainPage.xaml.cs
@@ -15,6 +15,10 @@ namespace Jammit.Forms
     {
       InitializeComponent();
 
+      //TODO: Defining a header throws a NullReferenceExeption in macOS starting with Xamarin.Forms 3.3.
+      if (Plugin.DeviceInfo.Abstractions.Platform.macOS == Plugin.DeviceInfo.CrossDeviceInfo.Current.Platform)
+        LibraryView.Header = null;
+
       double pad;
       if (Plugin.DeviceInfo.Abstractions.Platform.macOS == Plugin.DeviceInfo.CrossDeviceInfo.Current.Platform)
       {

--- a/Forms/Unjammit.Forms.csproj
+++ b/Forms/Unjammit.Forms.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="4.0.0.13" />
     <PackageReference Include="Xamarin.Essentials" Version="1.0.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.2.0.871581" />
+    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1009999" />
     <PackageReference Include="Xam.Plugins.Settings" Version="4.0.0.7" />
     <PackageReference Include="Xamarin.Plugin.FilePicker" Version="2.0.135" />
   </ItemGroup>

--- a/UWP/Unjammit.UWP.csproj
+++ b/UWP/Unjammit.UWP.csproj
@@ -127,7 +127,7 @@
       <Version>4.0.0.7</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
-      <Version>3.2.0.871581</Version>
+      <Version>3.4.0.1009999</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Plugin.FilePicker">
       <Version>2.0.135</Version>


### PR DESCRIPTION
Upgrade to the latest Xamarin.Forms stable release.

Note, there is a bug in versions newer than 3.2 that crashes the macOS app with a NullReferenceExeption when defining the library ListView header.
For now, removing such header in the macOS app.